### PR TITLE
Fix alternate full reload

### DIFF
--- a/UKCovidData.xcodeproj/project.pbxproj
+++ b/UKCovidData.xcodeproj/project.pbxproj
@@ -174,6 +174,7 @@
 		BF6A8DD626F2541A0084DF96 /* UKCovidData */ = {
 			isa = PBXGroup;
 			children = (
+				BF6A8E0626F262100084DF96 /* DataUpdater.swift */,
 				BF382E222703DEFC008213E6 /* Utilities */,
 				BF382E192703DC6B008213E6 /* ViewModels */,
 				BF382E182703DC4A008213E6 /* UseCases */,
@@ -186,7 +187,6 @@
 				BF6A8DE026F2541C0084DF96 /* Persistence.swift */,
 				BF6A8DE226F2541C0084DF96 /* UKCovidData.xcdatamodeld */,
 				BF6A8DDD26F2541C0084DF96 /* Preview Content */,
-				BF6A8E0626F262100084DF96 /* DataUpdater.swift */,
 			);
 			path = UKCovidData;
 			sourceTree = "<group>";

--- a/UKCovidData/DataUpdater.swift
+++ b/UKCovidData/DataUpdater.swift
@@ -81,7 +81,9 @@ final class DataUpdater {
             pageNumber += 1
         }
         // If no error thrown we can update the newestCasesDate
-        self.newestCasesDate = updatedLatestDate
+        if let updatedLatestDate = updatedLatestDate {
+            self.newestCasesDate = updatedLatestDate
+        }
     }
 
     fileprivate func updateCases(url: URL, container: NSPersistentContainer = PersistenceController.shared.container) async throws -> (Bool, String?) {


### PR DESCRIPTION
Doing a load when there was no new data would clear the latest data date so the next load would be a full one. Don't update the date to nil.